### PR TITLE
Allow to target the user configuration file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,4 +11,4 @@
 #   ServerAliveInterval: 300
 #   ServerAliveCountMax: 2
 ssh_config_host_configs: []
-ssh_config_system_wide: true
+ssh_config_path: "/etc/ssh/ssh_config"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@
 #   ServerAliveInterval: 300
 #   ServerAliveCountMax: 2
 ssh_config_host_configs: []
+ssh_config_system_wide: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,5 @@
 ---
 
-- set_fact: ssh_config_path="/etc/ssh/ssh_config"
-  when: ssh_config_system_wide
-
-- set_fact: ssh_config_path="~/.ssh/config"
-  when: not ssh_config_system_wide
-
 - name: copy ssh_config as wide system config
   template:
     src: "ssh_config.j2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,13 @@
 ---
-- name: copy ssh_config
+
+- set_fact: ssh_config_path="/etc/ssh/ssh_config"
+  when: ssh_config_system_wide
+
+- set_fact: ssh_config_path="~/.ssh/config"
+  when: not ssh_config_system_wide
+
+- name: copy ssh_config as wide system config
   template:
     src: "ssh_config.j2"
-    dest: "/etc/ssh/ssh_config"
+    dest: "{{ ssh_config_path }}"
     mode: 0644

--- a/templates/ssh_config.j2
+++ b/templates/ssh_config.j2
@@ -1,5 +1,6 @@
 # {{ ansible_managed }}
 #
+{% if ssh_config_system_wide %}
 # This is the ssh client system-wide configuration file.  See
 # ssh_config(5) for more information.  This file provides defaults for
 # users, and the values can be changed in per-user configuration files
@@ -16,6 +17,7 @@
 # Site-wide defaults for some commonly used options.  For a comprehensive
 # list of available options, their meanings and defaults, please see the
 # ssh_config(5) man page.
+{% endif %}
 
 {% for host_config in ssh_config_host_configs %}
 Host {{host_config.host}}

--- a/templates/ssh_config.j2
+++ b/templates/ssh_config.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 #
-{% if ssh_config_system_wide %}
+{% if ssh_config_path == "/etc/ssh/ssh_config" %}
 # This is the ssh client system-wide configuration file.  See
 # ssh_config(5) for more information.  This file provides defaults for
 # users, and the values can be changed in per-user configuration files


### PR DESCRIPTION
Add the boolean variable ssh_configuration_system_wide to target
/etc/ssh/ssh_config if true, ~/.ssh/config otherwise.
